### PR TITLE
AUT-10341 Add support for multiple dirs when reading config from fs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,6 @@ on:
       - master
       - dev
   pull_request:
-
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Merge configuration from a directory structure and push it into Cloudentity.
 
 To push configration from multiple directories, either pass an array to the `storage.dir_path` or use `STORAGE_DIR_PATH` with multiple paths split by a comma.
 
+Configurations are merged in the reverse order, so the first path has the highest priority, and will override everything else.
+
 ```bash
 cac --config examples/e2e/config.yaml push --workspace cdr_australia-demo-c67evw7mj4
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Merge configuration from a directory structure and push it into Cloudentity.
 
 #### Push configuration from multiple directories
 
-To push configration from multiple directories, either pass an array to the `storage.dir_path` or use `STORAGE_DIR_PATH` env variable multiple times.
+To push configration from multiple directories, either pass an array to the `storage.dir_path` or use `STORAGE_DIR_PATH` with multiple paths split by a comma.
 
 ```bash
 cac --config examples/e2e/config.yaml push --workspace cdr_australia-demo-c67evw7mj4

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ cac --config examples/e2e/config.yaml pull --workspace cdr_australia-demo-c67evw
 
 Merge configuration from a directory structure and push it into Cloudentity.
 
+#### Push configuration from multiple directories
+
+To push configration from multiple directories, either pass an array to the `storage.dir_path` or use `STORAGE_DIR_PATH` env variable multiple times.
+
 ```bash
 cac --config examples/e2e/config.yaml push --workspace cdr_australia-demo-c67evw7mj4
 ```

--- a/internal/cac/app.go
+++ b/internal/cac/app.go
@@ -11,7 +11,7 @@ import (
 type Application struct {
 	Config  *config.Configuration
 	Client  *client.Client
-	Storage *storage.Storage
+	Storage storage.Storage
 }
 
 func InitApp(configPath string) (app *Application, err error) {
@@ -31,7 +31,9 @@ func InitApp(configPath string) (app *Application, err error) {
 		return app, err
 	}
 
-	app.Storage = storage.InitStorage(app.Config.Storage)
+	if app.Storage, err = storage.InitMultiStorage(app.Config.Storage); err != nil {
+		return app, err
+	}
 
 	slog.With("app", app).Debug("Initiated application")
 

--- a/internal/cac/app.go
+++ b/internal/cac/app.go
@@ -25,7 +25,7 @@ func InitApp(configPath string) (app *Application, err error) {
 		return app, err
 	}
 
-	slog.Info("config", "c", app.Config.Client)
+	slog.Debug("config", "c", app.Config.Client)
 
 	if app.Client, err = client.InitClient(app.Config.Client); err != nil {
 		return app, err
@@ -35,7 +35,7 @@ func InitApp(configPath string) (app *Application, err error) {
 		return app, err
 	}
 
-	slog.With("app", app).Debug("Initiated application")
+	slog.Info("Initiated application")
 
 	return app, nil
 }

--- a/internal/cac/config/config.go
+++ b/internal/cac/config/config.go
@@ -18,14 +18,14 @@ var (
 	DefaultConfig = Configuration{
 		Client:  client.DefaultConfig,
 		Logging: logging.DefaultLoggingConfig,
-		Storage: storage.DefaultConfig,
+		Storage: storage.DefaultMultiStorageConfig,
 	}
 )
 
 type Configuration struct {
-	Client  client.Configuration  `json:"client"`
-	Logging logging.Configuration `json:"logging"`
-	Storage storage.Configuration `json:"storage"`
+	Client  client.Configuration              `json:"client"`
+	Logging logging.Configuration             `json:"logging"`
+	Storage storage.MultiStorageConfiguration `json:"storage"`
 }
 
 func InitConfig(path string) (_ *Configuration, err error) {

--- a/internal/cac/config/config.go
+++ b/internal/cac/config/config.go
@@ -75,7 +75,7 @@ func InitConfig(path string) (_ *Configuration, err error) {
 func configureDecoder(config *mapstructure.DecoderConfig) {
 	config.TagName = "json"
 	config.WeaklyTypedInput = true
-	config.DecodeHook = mapstructure.ComposeDecodeHookFunc(urlDecoder(), timeDecoder())
+	config.DecodeHook = mapstructure.ComposeDecodeHookFunc(urlDecoder(), timeDecoder(), stringToSlice())
 }
 
 func urlDecoder() mapstructure.DecodeHookFunc {
@@ -123,5 +123,23 @@ func timeDecoder() mapstructure.DecodeHookFunc {
 		default:
 			return data, nil
 		}
+	}
+}
+
+func stringToSlice() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data interface{}) (interface{}, error) {
+		if f != reflect.String || t != reflect.Slice {
+			return data, nil
+		}
+
+		raw := data.(string)
+		if raw == "" {
+			return []string{}, nil
+		}
+
+		return strings.Split(raw, ","), nil
 	}
 }

--- a/internal/cac/storage/multi.go
+++ b/internal/cac/storage/multi.go
@@ -1,0 +1,69 @@
+package storage
+
+import (
+	"github.com/cloudentity/acp-client-go/clients/hub/models"
+	"github.com/imdario/mergo"
+	"github.com/pkg/errors"
+)
+
+type MultiStorageConfiguration struct {
+	DirPath []string `json:"dir_path"`
+}
+
+var DefaultMultiStorageConfig = MultiStorageConfiguration{
+	DirPath: []string{"data"},
+}
+
+func InitMultiStorage(config MultiStorageConfiguration) (*MultiStorage, error) {
+	var storages []Storage
+
+	if len(config.DirPath) == 0 {
+		return nil, errors.New("at least one dir_path is required")
+	}
+
+	for _, config := range config.DirPath {
+		storages = append(storages, InitStorage(Configuration{
+			DirPath: config,
+		}))
+	}
+
+	return &MultiStorage{
+		Storages: storages,
+		Config:   config,
+	}, nil
+}
+
+type MultiStorage struct {
+	Storages []Storage
+	Config   MultiStorageConfiguration
+}
+
+var _ Storage = &MultiStorage{}
+
+// Store for simplicity stores data in first storage only, it is responsibility of the user to move entities to other storages
+func (m *MultiStorage) Store(workspace string, data *models.TreeServer) error {
+	return m.Storages[0].Store(workspace, data)
+}
+
+// Read data from all storages and merge them
+func (m *MultiStorage) Read(workspace string) (models.TreeServer, error) {
+	var (
+		data models.TreeServer
+		err  error
+	)
+
+	for i := len(m.Storages) - 1; i >= 0; i-- {
+		var data2 models.TreeServer
+
+		if data2, err = m.Storages[i].Read(workspace); err != nil {
+			return data, errors.Wrap(err, "failed to read data from storage")
+		}
+
+		if err = mergo.Merge(&data, data2, mergo.WithOverride); err != nil {
+			return data, errors.Wrap(err, "failed to merge data")
+		}
+
+	}
+
+	return data, nil
+}

--- a/internal/cac/storage/storage.go
+++ b/internal/cac/storage/storage.go
@@ -17,17 +17,24 @@ var DefaultConfig = Configuration{
 	DirPath: "data",
 }
 
-func InitStorage(config Configuration) *Storage {
-	return &Storage{
+func InitStorage(config Configuration) *SingleStorage {
+	return &SingleStorage{
 		Config: config,
 	}
 }
 
-type Storage struct {
+type Storage interface {
+	Store(workspace string, data *models.TreeServer) error
+	Read(workspace string) (models.TreeServer, error)
+}
+
+type SingleStorage struct {
 	Config Configuration
 }
 
-func (s *Storage) Store(workspace string, data *models.TreeServer) error {
+var _ Storage = &SingleStorage{}
+
+func (s *SingleStorage) Store(workspace string, data *models.TreeServer) error {
 	var (
 		workspacePath = s.workspacePath(workspace)
 		err           error
@@ -126,7 +133,7 @@ func (s *Storage) Store(workspace string, data *models.TreeServer) error {
 	return nil
 }
 
-func (s *Storage) Read(workspace string) (models.TreeServer, error) {
+func (s *SingleStorage) Read(workspace string) (models.TreeServer, error) {
 	var (
 		server = models.TreeServer{
 			Clients:              models.TreeClients{},
@@ -235,11 +242,11 @@ func (s *Storage) Read(workspace string) (models.TreeServer, error) {
 	return server, nil
 }
 
-func (s *Storage) workspacePath(workspace string) string {
+func (s *SingleStorage) workspacePath(workspace string) string {
 	return filepath.Join(s.Config.DirPath, "workspaces", workspace)
 }
 
-func (s *Storage) storeServer(workspace string, data *models.TreeServer) error {
+func (s *SingleStorage) storeServer(workspace string, data *models.TreeServer) error {
 	var (
 		path   = filepath.Join(s.workspacePath(workspace), "server")
 		server adminmodels.Server

--- a/internal/cac/storage/storage_test.go
+++ b/internal/cac/storage/storage_test.go
@@ -451,7 +451,6 @@ module.exports = async function(context) {
 
 			var files []string
 
-			// refactor the code below to loop over dirpath
 			for _, dir := range st.Config.DirPath {
 				err = filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 					if err != nil {


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/AUT-10341

## Release Notes Description (public)

Adds support to read configuration from multiple directories.

It is required to support configuration shared between different environments like:
- dev - development env configuration
- prod - production configuration
- base - configuration shared between dev and prod

It can be configured as below: 

```
(.env-dev)
storage:
  dir_path: ["/var/dev", "/var/base"]

(.env-prod)
storage:
  dir_path: ["/var/prod", "/var/base"]
```

The configurations are merged in the reversed order so anything in front of the list has a higher priority.

<!--- DESCRIPTION USED IN THE RELEASE NOTES

Remove this comment and replace it with the description of your changes for an external audience. 
This description will be pulled into public release notes.

1. What changes are you introducing? Be clear and provide a detailed overview of your changes.
2. Why are you introducing the changes? Make the intent of the changes clear.
    - What do those changes mean for our end users?
    - Why should they care?
    - What is the context of your changes?

Additionally:

- If your changes are breaking changes, provide information on how the change affects our customers and what is required from them to be updated.
  If you think a migration guide would be useful, let TWs know in advance.
- If your changes deprecate an API, provide what is the alternative for our customers (if it exists). State clearly that an API became deprecated.
-->

## Implementation details (internal)

<!--- Describe technical implementation details for peer reviewers -->

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
