### PR TITLE
Fix filtering exported configuration

### DIFF
--- a/internal/cac/client/mock_server_test.go
+++ b/internal/cac/client/mock_server_test.go
@@ -1,0 +1,69 @@
+package client_test
+
+import (
+	"github.com/cloudentity/acp-client-go/clients/hub/models"
+	"github.com/go-json-experiment/json"
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func CreateMockServer(t *testing.T) *httptest.Server {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+
+		if req.URL.Path == "/demo/system/.well-known/openid-configuration" {
+			js := []byte(`{
+"issuer": "https://demo.eu.authz.cloudentity.io/demo/system",
+"authorization_endpoint": "https://postmance.eu.authz.cloudentity.io/demo/system/oauth2/auth",
+"token_endpoint": "https://postmance.eu.authz.cloudentity.io/demo/system/oauth2/token"
+}`)
+			res.WriteHeader(http.StatusOK)
+			_, err := res.Write(js)
+			require.NoError(t, err)
+
+			return
+		}
+
+		if req.URL.Path == "/demo/system/oauth2/token" {
+			js := []byte(`{
+"token_type": "Bearer",
+"scope": "openid",
+"access_token": "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3",
+"expires_in": 3600
+}`)
+			res.Header().Set("Content-Type", "application/json")
+			res.WriteHeader(http.StatusOK)
+			_, err := res.Write(js)
+			require.NoError(t, err)
+
+			return
+		}
+
+		res.Header().Set("Content-Type", "application/json")
+		res.WriteHeader(http.StatusOK)
+		js, err := json.Marshal(models.TreeServer{
+			Name:           "demo workspace",
+			AccessTokenTTL: strfmt.Duration(10 * time.Minute),
+			Clients: models.TreeClients{
+				"client1": models.TreeClient{
+					ClientName: "client1",
+				},
+			},
+			Idps: models.TreeIDPs{
+				"idp1": models.TreeIDP{
+					Name: "idp1",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = res.Write(js)
+		require.NoError(t, err)
+		return
+	}))
+
+	return testServer
+}

--- a/internal/cac/client/mock_server_test.go
+++ b/internal/cac/client/mock_server_test.go
@@ -62,7 +62,6 @@ func CreateMockServer(t *testing.T) *httptest.Server {
 
 		_, err = res.Write(js)
 		require.NoError(t, err)
-		return
 	}))
 
 	return testServer

--- a/internal/cac/utils/model.go
+++ b/internal/cac/utils/model.go
@@ -74,10 +74,13 @@ var staticFilterMappings = map[string]string{
 }
 
 func FilterPatch(patch models.Rfc7396PatchOperation, filters []string) (models.Rfc7396PatchOperation, error) {
+	if len(filters) == 0 {
+		return patch, nil
+	}
+
 	var newPatch = models.Rfc7396PatchOperation{}
 
 	for _, filter := range filters {
-
 		if mapped, ok := staticFilterMappings[filter]; ok {
 			filter = mapped
 		}


### PR DESCRIPTION
## Release Notes Description (public)

Fix filtering exported configuration and add tests.

Before that fix, if filters were not provided, the client would return an empty object 
