### PR TITLE
Add an option to filter the data you want to push

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -25,7 +25,11 @@ var (
 				return err
 			}
 
-			if data, err = app.Storage.Read(cmd.Context(), api.WithWorkspace(rootConfig.Workspace)); err != nil {
+			if data, err = app.Storage.Read(
+				cmd.Context(),
+				api.WithWorkspace(rootConfig.Workspace),
+				api.WithFilters(pushConfig.Filters),
+			); err != nil {
 				return err
 			}
 
@@ -72,10 +76,11 @@ var (
 		},
 	}
 	pushConfig struct {
-		DryRun bool
-		Out    string
-		Mode   string
-		Method string
+		DryRun  bool
+		Out     string
+		Mode    string
+		Method  string
+		Filters []string
 	}
 )
 
@@ -84,6 +89,7 @@ func init() {
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Out, "out", "-", "Dry execution output. It can be a file, directory or '-' for stdout")
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Mode, "mode", "update", "One of ignore, fail, update")
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Method, "method", "", "One of patch (merges remote with your config before applying), import (replaces remote with your config)")
+	pushCmd.PersistentFlags().StringSliceVar(&pushConfig.Filters, "filter", []string{}, "Push only selected resources")
 
 	mustMarkRequired(pushCmd, "method")
 }

--- a/internal/cac/diff/diff.go
+++ b/internal/cac/diff/diff.go
@@ -56,6 +56,7 @@ var secretFields = []string{
 	"\\{models.Rfc7396PatchOperation\\}\\[\\\"jwks\\\"\\]", // workspace jwks (when comparing workspace config
 	"servers.*jwks", // workspace jwks (when comparing tenant config)
 	"webhooks.*api_key",
+	"mfa_methods.*auth",
 }
 
 var volatileFields = []string{


### PR DESCRIPTION
## Release Notes Description (public)

Add an option to filter the data you want to push. It is useful if you want to push workspace config separately to global configuration like ~ 

```
cac push --workspace default
cac push --workspace system
cac push --tenant --filter mfa_methods --filter pools --filter schemas --filter themes
```