### PR TITLE
[148773] Fix validation and encoding issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS build
+FROM golang:1.22 AS build
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -155,16 +155,19 @@ Usage:
   cac push [flags]
 
 Flags:
-      --dry-run            Write files to disk instead of pushing to server
-  -h, --help               help for push
-      --method string      One of patch (merges remote with your config before applying), import (replaces remote with your config)
-      --mode string        One of ignore, fail, update (default "update")
-      --out string         Dry execution output. It can be a file, directory or '-' for stdout (default "-")
-      --workspace string   Workspace to load
+      --dry-run          Write files to disk instead of pushing to server
+      --filter strings   Push only selected resources
+  -h, --help             help for push
+      --method string    One of patch (merges remote with your config before applying), import (replaces remote with your config)
+      --mode string      One of ignore, fail, update (default "update")
+      --no-validate      Temporary workaround to skip local validation, which in some cases does not validate a valid config
+      --out string       Dry execution output. It can be a file, directory or '-' for stdout (default "-")
 
 Global Flags:
-      --config string    Path to source configuration file
-      --profile string   Configuration profile
+      --config string      Path to source configuration file
+      --profile string     Configuration profile
+      --tenant             Tenant configuration
+      --workspace string   Workspace configuration
 ```
 
 #### Push configuration from multiple directories

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -92,7 +92,7 @@ func init() {
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Out, "out", "-", "Dry execution output. It can be a file, directory or '-' for stdout")
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Mode, "mode", "update", "One of ignore, fail, update")
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Method, "method", "", "One of patch (merges remote with your config before applying), import (replaces remote with your config)")
-	pushCmd.PersistentFlags().BoolVar(&pushConfig.NoLocalValidate, "no-validate", false, "temporary workaround to skip local validation, which in some cases does not validate a valid config")
+	pushCmd.PersistentFlags().BoolVar(&pushConfig.NoLocalValidate, "no-validate", false, "Temporary workaround to skip local validation, which in some cases does not validate a valid config")
 	pushCmd.PersistentFlags().StringSliceVar(&pushConfig.Filters, "filter", []string{}, "Push only selected resources")
 
 	mustMarkRequired(pushCmd, "method")

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -33,8 +33,10 @@ var (
 				return err
 			}
 
-			if err = app.Validator.Validate(&data); err != nil {
-				return errors.Wrap(err, "failed to validate configuration")
+			if !pushConfig.NoLocalValidate {
+				if err = app.Validator.Validate(&data); err != nil {
+					return errors.Wrap(err, "failed to validate configuration")
+				}
 			}
 
 			if pushConfig.DryRun {
@@ -76,11 +78,12 @@ var (
 		},
 	}
 	pushConfig struct {
-		DryRun  bool
-		Out     string
-		Mode    string
-		Method  string
-		Filters []string
+		DryRun     bool
+		Out        string
+		Mode       string
+		Method     string
+		Filters    []string
+		NoLocalValidate bool
 	}
 )
 
@@ -89,6 +92,7 @@ func init() {
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Out, "out", "-", "Dry execution output. It can be a file, directory or '-' for stdout")
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Mode, "mode", "update", "One of ignore, fail, update")
 	pushCmd.PersistentFlags().StringVar(&pushConfig.Method, "method", "", "One of patch (merges remote with your config before applying), import (replaces remote with your config)")
+	pushCmd.PersistentFlags().BoolVar(&pushConfig.NoLocalValidate, "no-validate", false, "temporary workaround to skip local validation, which in some cases does not validate a valid config")
 	pushCmd.PersistentFlags().StringSliceVar(&pushConfig.Filters, "filter", []string{}, "Push only selected resources")
 
 	mustMarkRequired(pushCmd, "method")

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/cloudentity/cac
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/cloudentity/acp-client-go v0.0.0-20240417080945-86a36fac2551
-	github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0
 	github.com/go-openapi/runtime v0.27.0
 	github.com/go-openapi/strfmt v0.22.0
 	github.com/goccy/go-yaml v1.11.2
@@ -27,6 +28,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.22.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0 h1:ymLjT4f35nQbASLnvxEde4XOBL+Sn7rFuV+FOJqkljg=
 github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0/go.mod h1:6daplAwHHGbUGib4990V3Il26O0OC4aRyvewaaAihaA=
+github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b h1:IM96IiRXFcd7l+mU8Sys9pcggoBLbH/dEgzOESrS8F8=
+github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b/go.mod h1:uDEMZSTQMj7V6Lxdrx4ZwchmHEGdICbjuY+GQd7j9LM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/cac/config/config.go
+++ b/internal/cac/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/cloudentity/cac/internal/cac/client"
 	"github.com/cloudentity/cac/internal/cac/logging"
 	"github.com/cloudentity/cac/internal/cac/storage"
@@ -9,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"golang.org/x/exp/slog"
-	"strings"
 )
 
 var (

--- a/internal/cac/storage/reader.go
+++ b/internal/cac/storage/reader.go
@@ -1,12 +1,13 @@
 package storage
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/cloudentity/cac/internal/cac/templates"
 	ccyaml "github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/slog"
-	"os"
-	"path/filepath"
 )
 
 type ReadFileOpts struct {
@@ -28,7 +29,7 @@ func readFile(path string, opts ...ReadFileOpt) (map[string]any, error) {
 	if filepath.Ext(path) == "" {
 		path += ".yaml"
 	}
-
+	
 	slog.Debug("reading file", "path", path)
 
 	if bts, err = templates.New(path).Render(); err != nil {
@@ -42,6 +43,7 @@ func readFile(path string, opts ...ReadFileOpt) (map[string]any, error) {
 
 	slog.Debug("read template", "path", path, "data", bts)
 
+	
 	if err = ccyaml.Unmarshal(bts, &out); err != nil {
 		return out, errors.Wrapf(err, "failed to unmarshal template %s", path)
 	}

--- a/internal/cac/storage/reader.go
+++ b/internal/cac/storage/reader.go
@@ -42,7 +42,6 @@ func readFile(path string, opts ...ReadFileOpt) (map[string]any, error) {
 
 	slog.Debug("read template", "path", path, "data", bts)
 
-	// using goccy/go-yaml instead of sigs.k8s.io/yaml because it is better at handling multiline strings
 	if err = ccyaml.Unmarshal(bts, &out); err != nil {
 		return out, errors.Wrapf(err, "failed to unmarshal template %s", path)
 	}

--- a/internal/cac/storage/server_storage_test.go
+++ b/internal/cac/storage/server_storage_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cloudentity/acp-client-go/clients/hub/models"
 	"github.com/cloudentity/cac/internal/cac/api"
-	"github.com/cloudentity/cac/internal/cac/config"
 	"github.com/cloudentity/cac/internal/cac/diff"
 	"github.com/cloudentity/cac/internal/cac/logging"
 	"github.com/cloudentity/cac/internal/cac/storage"
@@ -600,11 +599,7 @@ system: false`, string(bts))
     
     for _, tc := range tcs {
         t.Run(tc.desc, func(t *testing.T) {
-            _, err := config.InitConfig("")
-
-            require.NoError(t, err)
-
-            err = logging.InitLogging(&logging.Configuration{
+            err := logging.InitLogging(&logging.Configuration{
                 Level: "debug",
             })
 

--- a/internal/cac/storage/tenant_storage_test.go
+++ b/internal/cac/storage/tenant_storage_test.go
@@ -174,10 +174,10 @@ created_at: "0001-01-01T00:00:00.000Z"
 id: pages/error/index.tmpl
 updated_at: "0001-01-01T00:00:00.000Z"`, string(bts))
                 case "themes/theme1/templates/shared_footer.tmpl.yaml":
-                    require.Equal(t, `content: {{ include "shared_footer.tmpl" | nindent 2 }}
-created_at: "0001-01-01T00:00:00.000Z"
-id: shared/footer.tmpl
-updated_at: "0001-01-01T00:00:00.000Z"
+                    require.Equal(t, `id: shared/footer.tmpl
+content: {{ include "shared_footer.tmpl" | nindent 2 }}
+created_at: 0001-01-01T00:00:00.000Z
+updated_at: 0001-01-01T00:00:00.000Z
 `, string(bts))
                 }
             },

--- a/internal/cac/utils/yaml.go
+++ b/internal/cac/utils/yaml.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"bytes"
+
 	"github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
-	"sigs.k8s.io/yaml"
+	ccyaml "github.com/goccy/go-yaml"
 )
 
 func ToYaml(it any) ([]byte, error) {
@@ -14,7 +15,10 @@ func ToYaml(it any) ([]byte, error) {
 	)
 
 	buffer := bytes.NewBuffer(bts)
-	enc := jsontext.NewEncoder(buffer, json.FormatNilMapAsNull(true), json.FormatNilSliceAsNull(true))
+	enc := jsontext.NewEncoder(buffer, 
+		json.FormatNilMapAsNull(true), 
+		json.FormatNilSliceAsNull(true),
+	)
 
 	if err = json.MarshalEncode(enc, it); err != nil {
 		return bts, err
@@ -22,7 +26,7 @@ func ToYaml(it any) ([]byte, error) {
 
 	bts = buffer.Bytes()
 
-	if bts, err = yaml.JSONToYAML(bts); err != nil {
+	if bts, err = ccyaml.JSONToYAML(bts); err != nil {
 		return bts, err
 	}
 


### PR DESCRIPTION
## Jira task -148773

## Release Notes Description (public)

1. Added a 'no-validate' flag to push command as a workaround for cases where the generated swagger client is too strict and requires properties of optional structs

2. Prevented using complex encoding for long yaml keys by switching to [goccy/go-yaml](https://github.com/goccy/go-yaml) library 