### PR TITLE
Fix vanity domain support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,9 @@ toolchain go1.22.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/cloudentity/acp-client-go v0.0.0-20240417080945-86a36fac2551
-	github.com/go-openapi/runtime v0.27.0
+	github.com/cloudentity/acp-client-go v0.0.0-20240618142147-15447bea0396
+	github.com/corvus-ch/zbase32 v1.0.0
+	github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b
 	github.com/go-openapi/strfmt v0.22.0
 	github.com/goccy/go-yaml v1.11.2
 	github.com/google/go-cmp v0.6.0
@@ -18,18 +19,15 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
-	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/corvus-ch/zbase32 v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.22.2 // indirect
@@ -37,6 +35,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.20.2 // indirect
 	github.com/go-openapi/jsonreference v0.20.4 // indirect
 	github.com/go-openapi/loads v0.21.5 // indirect
+	github.com/go-openapi/runtime v0.27.0 // indirect
 	github.com/go-openapi/spec v0.20.14 // indirect
 	github.com/go-openapi/swag v0.22.8 // indirect
 	github.com/go-openapi/validate v0.22.6 // indirect
@@ -78,6 +77,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/corvus-ch/zbase32.v1 v1.0.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/cloudentity/acp-client-go v0.0.0-20240417080945-86a36fac2551 h1:XoE1lxsNirhI8X6w1uKdAKtgcXbGOZYUs2aMLn0ErbI=
-github.com/cloudentity/acp-client-go v0.0.0-20240417080945-86a36fac2551/go.mod h1:dTHIsfs5YtDOH2CgeoHFlhfnnU1X+ohn+TIU30WlWQQ=
+github.com/cloudentity/acp-client-go v0.0.0-20240618142147-15447bea0396 h1:nWtlxPLa9os1mp4ASp3R9a+hcQo6hJWv15kYqNXXGyA=
+github.com/cloudentity/acp-client-go v0.0.0-20240618142147-15447bea0396/go.mod h1:dTHIsfs5YtDOH2CgeoHFlhfnnU1X+ohn+TIU30WlWQQ=
 github.com/corvus-ch/zbase32 v1.0.0 h1:pDV0qZ1g+HYA8P0PbULsgUg/tZue1FIjsZ7r7h4nZeU=
 github.com/corvus-ch/zbase32 v1.0.0/go.mod h1:A7KLRecF1tysURyoqiJBvMJFmt/ccqkRdDTLjlQeVsU=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -22,8 +22,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0 h1:ymLjT4f35nQbASLnvxEde4XOBL+Sn7rFuV+FOJqkljg=
-github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0/go.mod h1:6daplAwHHGbUGib4990V3Il26O0OC4aRyvewaaAihaA=
 github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b h1:IM96IiRXFcd7l+mU8Sys9pcggoBLbH/dEgzOESrS8F8=
 github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b/go.mod h1:uDEMZSTQMj7V6Lxdrx4ZwchmHEGdICbjuY+GQd7j9LM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -68,7 +66,6 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -233,6 +230,8 @@ google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/corvus-ch/zbase32.v1 v1.0.0 h1:K4u1NprbDNvKPczKfHLbwdOWHTZ0zfv2ow71H1nRnFU=
+gopkg.in/corvus-ch/zbase32.v1 v1.0.0/go.mod h1:T3oKkPOm4AV/bNXCNFUxRmlE9RUyBz/DSo0nK9U+c0Y=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
@@ -242,5 +241,3 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
-sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/internal/cac/client/client.go
+++ b/internal/cac/client/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cloudentity/acp-client-go/clients/hub/models"
 	"github.com/cloudentity/cac/internal/cac/api"
 	"github.com/cloudentity/cac/internal/cac/utils"
-	"github.com/go-openapi/runtime"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/slog"
 	"net/http"
@@ -69,6 +68,7 @@ func (c *Client) Read(ctx context.Context, opts ...api.SourceOpt) (models.Rfc739
 			NewExportWorkspaceConfigParams().
 			WithContext(ctx).
 			WithWithCredentials(&options.Secrets).
+			WithTid(c.acp.Config.TenantID).
 			WithWid(workspace), nil); err != nil {
 		return nil, err
 	}
@@ -125,10 +125,9 @@ func (c *Client) Patch(ctx context.Context, workspace string, mode string, data 
 			NewPatchWorkspaceConfigRfc7396Params().
 			WithContext(ctx).
 			WithWid(workspace).
+			WithTid(c.acp.Config.TenantID).
 			WithMode(&mode).
-			WithPatch(data), nil, func(operation *runtime.ClientOperation) {
-			operation.PathPattern = "/workspaces/{wid}/promote/config-rfc7396"
-		}); err != nil {
+			WithPatch(data), nil); err != nil {
 		return err
 	}
 
@@ -150,10 +149,9 @@ func (c *Client) Import(ctx context.Context, workspace string, mode string, data
 			NewImportWorkspaceConfigParams().
 			WithContext(ctx).
 			WithWid(workspace).
+			WithTid(c.acp.Config.TenantID).
 			WithMode(&mode).
-			WithConfig(out), nil, func(operation *runtime.ClientOperation) {
-			operation.PathPattern = "/workspaces/{wid}/promote/config"
-		}); err != nil {
+			WithConfig(out), nil); err != nil {
 		return err
 	}
 

--- a/internal/cac/client/client_test.go
+++ b/internal/cac/client/client_test.go
@@ -18,6 +18,7 @@ func TestClient(t *testing.T) {
 		_, err := client.InitClient(&client.Configuration{
 			Config: acpclient.Config{
 				IssuerURL:    issuer,
+				TenantID:    "postmance",
 				ClientID:     "fb346c287c4d4e378cbae39aa0c3fe52",
 				ClientSecret: "-T1siRsUvmE58hB-2I_fWQZW1lLpk_gK76ZziR8Y9QY",
 			},
@@ -32,6 +33,7 @@ func TestClient(t *testing.T) {
 		_, err := client.InitClient(&client.Configuration{
 			Config: acpclient.Config{
 				IssuerURL:    issuer,
+				TenantID:    "postmance",
 				ClientID:     "fb346c287c4d4e378cbae39aa0c3fe52",
 				ClientSecret: "-T1siRsUvmE58hB-2I_fWQZW1lLpk_gK76ZziR8Y9QY",
 			},
@@ -47,6 +49,7 @@ func TestClient(t *testing.T) {
 		c, err := client.InitClient(&client.Configuration{
 			Config: acpclient.Config{
 				IssuerURL:    issuer,
+				TenantID:    "postmance",
 				ClientID:     "fb346c287c4d4e378cbae39aa0c3fe52",
 				ClientSecret: "invalid_secret",
 			},
@@ -61,12 +64,13 @@ func TestClient(t *testing.T) {
 
 	t.Run("client pull configuration without filters", func(t *testing.T) {
 		testServer := CreateMockServer(t)
-		issuer, _ := url.Parse(fmt.Sprintf("%s/demo/system", testServer.URL))
+		issuer, _ := url.Parse(fmt.Sprintf("%s/postmance/system", testServer.URL))
 
 		c, err := client.InitClient(&client.Configuration{
 			Insecure: true,
 			Config: acpclient.Config{
 				IssuerURL:    issuer,
+				TenantID:    "postmance",
 				ClientID:     "fb346c287c4d4e378cbae39aa0c3fe52",
 				ClientSecret: "valid_secret",
 			},
@@ -88,12 +92,13 @@ func TestClient(t *testing.T) {
 
 	t.Run("client pull configuration and filter", func(t *testing.T) {
 		testServer := CreateMockServer(t)
-		issuer, _ := url.Parse(fmt.Sprintf("%s/demo/system", testServer.URL))
+		issuer, _ := url.Parse(fmt.Sprintf("%s/postmance/system", testServer.URL))
 
 		c, err := client.InitClient(&client.Configuration{
 			Insecure: true,
 			Config: acpclient.Config{
 				IssuerURL:    issuer,
+				TenantID:    "postmance",
 				ClientID:     "fb346c287c4d4e378cbae39aa0c3fe52",
 				ClientSecret: "valid_secret",
 			},
@@ -115,12 +120,13 @@ func TestClient(t *testing.T) {
 
 	t.Run("client pull tenant configuration", func(t *testing.T) {
 		testServer := CreateMockServer(t)
-		issuer, _ := url.Parse(fmt.Sprintf("%s/demo/system", testServer.URL))
+		issuer, _ := url.Parse(fmt.Sprintf("%s/postmance/system", testServer.URL))
 
 		c, err := client.InitClient(&client.Configuration{
 			Insecure: true,
 			Config: acpclient.Config{
 				IssuerURL:    issuer,
+				TenantID:    "postmance",
 				ClientID:     "fb346c287c4d4e378cbae39aa0c3fe52",
 				ClientSecret: "valid_secret",
 			},

--- a/internal/cac/client/mock_server_test.go
+++ b/internal/cac/client/mock_server_test.go
@@ -14,7 +14,7 @@ import (
 func CreateMockServer(t *testing.T) *httptest.Server {
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 
-		if req.URL.Path == "/demo/system/.well-known/openid-configuration" {
+		if req.URL.Path == "/postmance/system/.well-known/openid-configuration" {
 			js := []byte(`{
 "issuer": "https://demo.eu.authz.cloudentity.io/demo/system",
 "authorization_endpoint": "https://postmance.eu.authz.cloudentity.io/demo/system/oauth2/auth",
@@ -27,7 +27,7 @@ func CreateMockServer(t *testing.T) *httptest.Server {
 			return
 		}
 
-		if req.URL.Path == "/demo/system/oauth2/token" {
+		if req.URL.Path == "/postmance/system/oauth2/token" {
 			js := []byte(`{
 "token_type": "Bearer",
 "scope": "openid",
@@ -42,7 +42,7 @@ func CreateMockServer(t *testing.T) *httptest.Server {
 			return
 		}
 
-		if req.URL.Path == "/api/hub/demo//promote/config" {
+		if req.URL.Path == "/api/hub/postmance/promote/config" {
 			res.Header().Set("Content-Type", "application/json")
 			res.WriteHeader(http.StatusOK)
 			js, err := json.Marshal(models.TreeTenant{

--- a/internal/cac/client/tenant_client.go
+++ b/internal/cac/client/tenant_client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cloudentity/acp-client-go/clients/hub/models"
 	"github.com/cloudentity/cac/internal/cac/api"
 	"github.com/cloudentity/cac/internal/cac/utils"
-	"github.com/go-openapi/runtime"
 )
 
 type TenantClient struct {
@@ -97,9 +96,7 @@ func (t *TenantClient) Patch(ctx context.Context, mode string, data models.Rfc73
 	if _, err = t.acp.Hub.TenantConfiguration.PatchTenantConfigRfc7396(tenant_configuration.NewPatchTenantConfigRfc7396ParamsWithContext(ctx).
 		WithTid(t.acp.Config.TenantID).
 		WithMode(&mode).
-		WithPatch(data), nil, func(operation *runtime.ClientOperation) {
-		operation.PathPattern = "/promote/config-rfc7396"
-	},
+		WithPatch(data), nil,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix vanity domain support:
- update acp-client-go to the version with corrected paths for hub module
- do not override paths