### PR TITLE
Fix filter overrides with nil

### DIFF
--- a/internal/cac/storage/multi.go
+++ b/internal/cac/storage/multi.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+
 	"github.com/cloudentity/acp-client-go/clients/hub/models"
 	"github.com/cloudentity/cac/internal/cac/api"
 	"github.com/imdario/mergo"

--- a/internal/cac/storage/tenant_storage.go
+++ b/internal/cac/storage/tenant_storage.go
@@ -115,6 +115,10 @@ func (t *TenantStorage) Read(ctx context.Context, opts ...api.SourceOpt) (models
         return nil, err
     }
 
+    if err = readFilesToMap(tenant, "themes", filepath.Join(path, "themes")); err != nil {
+        return nil, err
+    }
+
     if themeDirs, err = listDirsInPath(filepath.Join(path, "themes")); err != nil {
         return nil, err
     }

--- a/internal/cac/storage/tenant_storage.go
+++ b/internal/cac/storage/tenant_storage.go
@@ -115,10 +115,6 @@ func (t *TenantStorage) Read(ctx context.Context, opts ...api.SourceOpt) (models
         return nil, err
     }
 
-    if err = readFilesToMap(tenant, "themes", filepath.Join(path, "themes")); err != nil {
-        return nil, err
-    }
-
     if themeDirs, err = listDirsInPath(filepath.Join(path, "themes")); err != nil {
         return nil, err
     }
@@ -144,7 +140,7 @@ func (t *TenantStorage) Read(ctx context.Context, opts ...api.SourceOpt) (models
             templatesConfig map[string]any
         )
 
-        if templatesConfig, err = readFiles(filepath.Join(path, "themes", normalize(theme.Name), "templates")); err != nil {
+        if templatesConfig, err = readFiles(filepath.Join(path, "themes", dir, "templates")); err != nil {
             return nil, err
         }
 

--- a/internal/cac/storage/tenant_storage_test.go
+++ b/internal/cac/storage/tenant_storage_test.go
@@ -195,7 +195,7 @@ updated_at: 0001-01-01T00:00:00.000Z
             st, err := storage.InitMultiStorage(&storage.MultiStorageConfiguration{
                 DirPath: []string{t.TempDir(), t.TempDir()},
             }, storage.InitTenantStorage)
-q
+
             require.NoError(t, err)
 
             patchData, err := utils.FromModelToPatch(tc.data)

--- a/internal/cac/storage/tenant_storage_test.go
+++ b/internal/cac/storage/tenant_storage_test.go
@@ -195,7 +195,7 @@ updated_at: 0001-01-01T00:00:00.000Z
             st, err := storage.InitMultiStorage(&storage.MultiStorageConfiguration{
                 DirPath: []string{t.TempDir(), t.TempDir()},
             }, storage.InitTenantStorage)
-
+q
             require.NoError(t, err)
 
             patchData, err := utils.FromModelToPatch(tc.data)

--- a/internal/cac/utils/model.go
+++ b/internal/cac/utils/model.go
@@ -85,7 +85,9 @@ func FilterPatch(patch models.Rfc7396PatchOperation, filters []string) (models.R
 			filter = mapped
 		}
 
-		newPatch[filter] = patch[filter]
+		if _, ok := patch[filter]; ok {
+			newPatch[filter] = patch[filter]
+		}
 	}
 
 	return newPatch, nil


### PR DESCRIPTION
Previously, if the filters were provided, the empty values from the secondary data storage overrode those from the base storage with nils

Example:

Config:
```
storage_paths: ./base, ./dev
```

base config:
```
themes:
    some_theme:
        (...)
```

dev config:

```
themes: (undefined)
```

result:
```
themes: nil
```


After the fix `themes` from the example are no longer overridden. 