### PR TITLE
Fix valid yaml parsing error and conditionally propagate 'with_credentials' flag to the tenant client

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -28,7 +28,7 @@ var (
 				With("tenant", rootConfig.Tenant).
 				With("filters", pullConfig.Filters).
 				With("config", rootConfig.ConfigPath).
-				Info("Pulling workspace configuration")
+				Info("Pulling configuration")
 
 			if data, err = app.Client.Read(
 				cmd.Context(),

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/corvus-ch/zbase32 v1.0.0
 	github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b
 	github.com/go-openapi/strfmt v0.22.0
-	github.com/goccy/go-yaml v1.11.2
+	github.com/goccy/go-yaml v1.12.0
 	github.com/google/go-cmp v0.6.0
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7a
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/goccy/go-yaml v1.11.2 h1:joq77SxuyIs9zzxEjgyLBugMQ9NEgTWxXfz2wVqwAaQ=
 github.com/goccy/go-yaml v1.11.2/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
+github.com/goccy/go-yaml v1.12.0 h1:/1WHjnMsI1dlIBQutrvSMGZRQufVO3asrHfTwfACoPM=
+github.com/goccy/go-yaml v1.12.0/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=

--- a/internal/cac/client/client.go
+++ b/internal/cac/client/client.go
@@ -63,6 +63,8 @@ func (c *Client) Read(ctx context.Context, opts ...api.SourceOpt) (models.Rfc739
 		return nil, errors.New("workspace is required to read using server client")
 	}
 
+	slog.Info("Pulling configuration", "workspace", workspace, "options", options)
+
 	if ok, err = c.acp.Hub.WorkspaceConfiguration.
 		ExportWorkspaceConfig(workspace_configuration.
 			NewExportWorkspaceConfigParams().

--- a/internal/cac/client/mock_server_test.go
+++ b/internal/cac/client/mock_server_test.go
@@ -14,79 +14,92 @@ import (
 func CreateMockServer(t *testing.T) *httptest.Server {
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 
-		if req.URL.Path == "/postmance/system/.well-known/openid-configuration" {
-			js := []byte(`{
+	if req.URL.Path == "/postmance/system/.well-known/openid-configuration" {
+		js := []byte(`{
 "issuer": "https://demo.eu.authz.cloudentity.io/demo/system",
 "authorization_endpoint": "https://postmance.eu.authz.cloudentity.io/demo/system/oauth2/auth",
 "token_endpoint": "https://postmance.eu.authz.cloudentity.io/demo/system/oauth2/token"
 }`)
-			res.WriteHeader(http.StatusOK)
-			_, err := res.Write(js)
-			require.NoError(t, err)
+		res.WriteHeader(http.StatusOK)
+		_, err := res.Write(js)
+		require.NoError(t, err)
 
-			return
-		}
+		return
+	}
 
-		if req.URL.Path == "/postmance/system/oauth2/token" {
-			js := []byte(`{
+	if req.URL.Path == "/postmance/system/oauth2/token" {
+		js := []byte(`{
 "token_type": "Bearer",
 "scope": "openid",
 "access_token": "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3",
 "expires_in": 3600
 }`)
-			res.Header().Set("Content-Type", "application/json")
-			res.WriteHeader(http.StatusOK)
-			_, err := res.Write(js)
-			require.NoError(t, err)
-
-			return
-		}
-
-		if req.URL.Path == "/api/hub/postmance/promote/config" {
-			res.Header().Set("Content-Type", "application/json")
-			res.WriteHeader(http.StatusOK)
-			js, err := json.Marshal(models.TreeTenant{
-				Name: "demo tenant",
-				Servers: models.TreeServers{
-					"server1": models.TreeServer{
-						Name: "demo workspace",
-					},
-				},
-				MfaMethods: models.TreeMFAMethods{
-					"sms": models.TreeMFAMethod{
-						Enabled: true,
-					},
-				},
-			})
-			require.NoError(t, err)
-
-			_, err = res.Write(js)
-			require.NoError(t, err)
-
-			return
-		}
-
 		res.Header().Set("Content-Type", "application/json")
 		res.WriteHeader(http.StatusOK)
-		js, err := json.Marshal(models.TreeServer{
-			Name:           "demo workspace",
-			AccessTokenTTL: strfmt.Duration(10 * time.Minute),
-			Clients: models.TreeClients{
-				"client1": models.TreeClient{
-					ClientName: "client1",
+		_, err := res.Write(js)
+		require.NoError(t, err)
+
+		return
+	}
+
+	if req.URL.Path == "/api/hub/postmance/promote/config" {
+		res.Header().Set("Content-Type", "application/json")
+		res.WriteHeader(http.StatusOK)
+		tt := models.TreeTenant{
+			Name: "demo tenant",
+			Servers: models.TreeServers{
+				"server1": models.TreeServer{
+					Name: "demo workspace",
+					Clients: models.TreeClients{
+						"cid1": models.TreeClient{
+							ClientName: "client1",
+						},
+					},
 				},
 			},
-			Idps: models.TreeIDPs{
-				"idp1": models.TreeIDP{
-					Name: "idp1",
+			MfaMethods: models.TreeMFAMethods{
+				"sms": models.TreeMFAMethod{
+					Enabled: true,
 				},
 			},
-		})
+		}
+
+		if req.URL.Query().Get("with_credentials") != "" {
+			s := tt.Servers["server1"]
+			c :=s.Clients["cid1"]
+			c.ClientSecret = "secret"
+			s.Clients["cid1"] = c
+		}
+
+		js, err := json.Marshal(tt)
 		require.NoError(t, err)
 
 		_, err = res.Write(js)
 		require.NoError(t, err)
-	}))
 
-	return testServer
+		return
+	}
+
+	res.Header().Set("Content-Type", "application/json")
+	res.WriteHeader(http.StatusOK)
+	js, err := json.Marshal(models.TreeServer{
+		Name:           "demo workspace",
+		AccessTokenTTL: strfmt.Duration(10 * time.Minute),
+		Clients: models.TreeClients{
+			"client1": models.TreeClient{
+				ClientName: "client1",
+			},
+		},
+		Idps: models.TreeIDPs{
+			"idp1": models.TreeIDP{
+				Name: "idp1",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = res.Write(js)
+	require.NoError(t, err)
+	}))
+return testServer
 }

--- a/internal/cac/client/tenant_client.go
+++ b/internal/cac/client/tenant_client.go
@@ -3,11 +3,13 @@ package client
 import (
 	"context"
 	"fmt"
+
 	acpclient "github.com/cloudentity/acp-client-go"
 	"github.com/cloudentity/acp-client-go/clients/hub/client/tenant_configuration"
 	"github.com/cloudentity/acp-client-go/clients/hub/models"
 	"github.com/cloudentity/cac/internal/cac/api"
 	"github.com/cloudentity/cac/internal/cac/utils"
+	"golang.org/x/exp/slog"
 )
 
 type TenantClient struct {
@@ -26,8 +28,11 @@ func (t *TenantClient) Read(ctx context.Context, opts ...api.SourceOpt) (models.
 		opt(options)
 	}
 
+	slog.Info("Pulling tenant configuration", "options", options)
+
 	if ok, err = t.acp.Hub.TenantConfiguration.ExportTenantConfig(tenant_configuration.NewExportTenantConfigParamsWithContext(ctx).
-		WithTid(t.acp.Config.TenantID), nil,
+		WithTid(t.acp.Config.TenantID).
+		WithWithCredentials(&options.Secrets), nil,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/cac/storage/dry.go
+++ b/internal/cac/storage/dry.go
@@ -2,11 +2,13 @@ package storage
 
 import (
 	"context"
+	"log/slog"
+	"os"
+
 	"github.com/cloudentity/acp-client-go/clients/hub/models"
 	"github.com/cloudentity/cac/internal/cac/api"
 	"github.com/cloudentity/cac/internal/cac/utils"
 	"github.com/pkg/errors"
-	"os"
 )
 
 type DryStorage struct {
@@ -20,6 +22,7 @@ func InitDryStorage(out string, constr Constructor) (*DryStorage, error) {
 	)
 
 	if out == "-" {
+		slog.Debug("Writing to stdout")
 		delegatedWriter = stdWriter
 	} else if out != "" {
 		var (
@@ -38,6 +41,7 @@ func InitDryStorage(out string, constr Constructor) (*DryStorage, error) {
 			}
 
 			if info.IsDir() {
+				slog.Debug("Writing to directory %s", "directory", out)
 				dryStorage := constr(&Configuration{
 					DirPath: out,
 				})
@@ -47,6 +51,7 @@ func InitDryStorage(out string, constr Constructor) (*DryStorage, error) {
 		}
 
 		if delegatedWriter == nil {
+			slog.Debug("Writing to file %s", "file", out)
 			delegatedWriter = flatFileWriter(out)
 		}
 	} else {

--- a/internal/cac/storage/server_storage_test.go
+++ b/internal/cac/storage/server_storage_test.go
@@ -396,9 +396,7 @@ url: https://example.com`, string(bts))
                         Definition: `
 package acp.authz
 
-default allow = false
-
-`,
+default allow = false`,
                         Language:   "rego",
                         PolicyName: "Some Rego Policy",
                         Type:       "api",
@@ -422,9 +420,7 @@ validators: []
                     require.Equal(t, `
 package acp.authz
 
-default allow = false
-
-`, string(bts))
+default allow = false`, string(bts))
                 }
             },
         },


### PR DESCRIPTION
1. Fix a bug where the `with-secrets` flag was not propagated to the tenant export. 
2. Update go-yaccy lib, to fix: `unterminated flow mapping` error