### PR TITLE
allow deleting script execution points

### DIFF
--- a/internal/cac/data/script_execution_points_validation.go
+++ b/internal/cac/data/script_execution_points_validation.go
@@ -1,0 +1,24 @@
+package data
+
+import (
+	"github.com/cloudentity/acp-client-go/clients/hub/models"
+)
+
+// workaround to pass too strict generated client validation when someone is trying to delete script execution points
+func allowToDeleteScriptExecutionPoints(ts *models.TreeServer) {
+	if ts.ScriptExecutionPoints == nil {
+		return
+	}
+
+	for typeID, typee := range ts.ScriptExecutionPoints {
+		for scriptID, script := range typee {
+			// empty scriptID means that script is being deleted
+			if script.ScriptID == "" {
+				// scriptID is required, so we need to set it to some value to pass validation 
+				script.ScriptID = "[DELETED]"
+				typee[scriptID] = script
+			}
+		}
+		ts.ScriptExecutionPoints[typeID] = typee
+	}
+}

--- a/internal/cac/data/server_validator.go
+++ b/internal/cac/data/server_validator.go
@@ -19,6 +19,8 @@ func (sv *ServerValidator) Validate(data *models.Rfc7396PatchOperation) error {
 		return err
 	}
 
+	allowToDeleteScriptExecutionPoints(serv)
+
 	if err = serv.Validate(strfmt.Default); err != nil {
 		return err
 	}

--- a/internal/cac/data/tenant_validator.go
+++ b/internal/cac/data/tenant_validator.go
@@ -19,6 +19,10 @@ func (sv *TenantValidator) Validate(data *models.Rfc7396PatchOperation) error {
 		return err
 	}
 
+	for _, server := range tenant.Servers {
+		allowToDeleteScriptExecutionPoints(&server)
+	}
+
 	if err = tenant.Validate(strfmt.Default); err != nil {
 		return err
 	}

--- a/internal/cac/data/validator_test.go
+++ b/internal/cac/data/validator_test.go
@@ -1,0 +1,34 @@
+package data_test
+
+import (
+	"testing"
+
+	"github.com/cloudentity/cac/internal/cac/data"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudentity/acp-client-go/clients/hub/models"
+)
+
+func TestServerValidator(t *testing.T) {
+	validator := &data.TenantValidator{}
+	
+	t.Run("allow_script_exec_point_deletion", func(t *testing.T) {
+		patch := models.Rfc7396PatchOperation{
+			"servers": map[string]any{
+				"server1": map[string]any{
+					"script_execution_points": map[string]any{
+						"client_token_minting": map[string]any{
+							"cid1": map[string]any{
+								"script_id": "",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := validator.Validate(&patch)
+		require.NoError(t, err)
+	})
+
+}


### PR DESCRIPTION
Allow deleting script execution points during patch requests by configuring the script id attribute to an empty string: 

```
script_execution_points:
    client_token_minting:
        [CLIENT_ID]:
            script_id: ""
```