### PR TITLE
fix downloading pre-built binary

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,14 +12,32 @@ runs:
   using: 'composite'
   steps:
     # github.action_ref is empty inside a composite action's run steps (and
-    # leaks the ref of `uses:` steps like actions/cache). github.action_path is
-    # reliable; its last segment is the ref: .../_actions/<owner>/<repo>/<ref>
-    - name: Resolve action ref
+    # leaks the ref of `uses:` steps like actions/cache), so we resolve the
+    # release repo/tag ourselves.
+    #
+    # When the action is consumed remotely (uses: owner/repo@ref) github.action_path
+    # is .../_actions/<owner>/<repo>/<ref>, so both repo and version come from it.
+    # When it is used locally (uses: ./) github.action_path is just the checked-out
+    # repo directory, so we fall back to the caller repo plus the checked-out tag
+    # (github.ref_name is the workflow trigger ref, which is not the tag for
+    # release-testing jobs, so prefer the exact tag git actually checked out).
+    - name: Resolve action repo and version
       id: meta
       shell: bash
       run: |
         AP="${{ github.action_path }}"
-        echo "version=${AP##*/}" >> "$GITHUB_OUTPUT"
+        if [[ "$AP" == *"/_actions/"* ]]; then
+          REST="${AP#*/_actions/}"
+          OWNER="${REST%%/*}"; REST="${REST#*/}"
+          NAME="${REST%%/*}"; REF="${REST#*/}"
+          REPO="${OWNER}/${NAME}"
+          VERSION="${REF}"
+        else
+          REPO="${{ github.repository }}"
+          VERSION="$(git -C "$AP" describe --tags --exact-match 2>/dev/null || echo "${{ github.ref_name }}")"
+        fi
+        echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Restore cached binary
       id: cache
@@ -35,7 +53,7 @@ runs:
       continue-on-error: true
       run: |
         VERSION="${{ steps.meta.outputs.version }}"
-        REPO="SecureAuthCorp/ciam-config-as-code"
+        REPO="${{ steps.meta.outputs.repo }}"
 
         ARCH=$(uname -m)
         case "$ARCH" in

--- a/action.yaml
+++ b/action.yaml
@@ -11,12 +11,22 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # github.action_ref is empty inside a composite action's run steps (and
+    # leaks the ref of `uses:` steps like actions/cache). github.action_path is
+    # reliable; its last segment is the ref: .../_actions/<owner>/<repo>/<ref>
+    - name: Resolve action ref
+      id: meta
+      shell: bash
+      run: |
+        AP="${{ github.action_path }}"
+        echo "version=${AP##*/}" >> "$GITHUB_OUTPUT"
+
     - name: Restore cached binary
       id: cache
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /tmp/cac
-        key: cac-${{ runner.os }}-${{ runner.arch }}-${{ github.action_ref || github.ref_name }}
+        key: cac-${{ runner.os }}-${{ runner.arch }}-${{ steps.meta.outputs.version }}
 
     - name: Download pre-built binary
       id: download
@@ -24,8 +34,8 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        VERSION="${{ github.action_ref || github.ref_name }}"
-        REPO="${{ github.action_repository }}"
+        VERSION="${{ steps.meta.outputs.version }}"
+        REPO="SecureAuthCorp/ciam-config-as-code"
 
         ARCH=$(uname -m)
         case "$ARCH" in


### PR DESCRIPTION
# Fix downloading pre-built binary.

Before this PR, both REPO and VERSION variables were not properly resolved, which required rebuilding it during action execution  