### PR TITLE
feat: extend tenant storage with tenant.yaml file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/cloudentity/acp-client-go v0.0.0-20260410101459-b244b5048247
+	github.com/cloudentity/acp-client-go v0.0.0-20260527095100-008ff5049411
 	github.com/corvus-ch/zbase32 v1.0.0
 	github.com/go-json-experiment/json v0.0.0-20240524174822-2d9f40f7385b
 	github.com/go-openapi/strfmt v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/cloudentity/acp-client-go v0.0.0-20260410101459-b244b5048247 h1:TjlzXba4WIAE4INjq+bhKhl8yhS4iXGwB7leztdAKIA=
-github.com/cloudentity/acp-client-go v0.0.0-20260410101459-b244b5048247/go.mod h1:vfVPwSn1JfwCOheMlqGmF1NPGio88S8jdiXOzQYjCeY=
+github.com/cloudentity/acp-client-go v0.0.0-20260527095100-008ff5049411 h1:oty7npFWtmLAegF5gYXQAAsY2DOZ7WxcCZVVqBSeIwE=
+github.com/cloudentity/acp-client-go v0.0.0-20260527095100-008ff5049411/go.mod h1:Hr2WHHXmp+DC4B2oprhgP47yl/dsCAyj9HcG6P3z4m0=
 github.com/corvus-ch/zbase32 v1.0.0 h1:pDV0qZ1g+HYA8P0PbULsgUg/tZue1FIjsZ7r7h4nZeU=
 github.com/corvus-ch/zbase32 v1.0.0/go.mod h1:A7KLRecF1tysURyoqiJBvMJFmt/ccqkRdDTLjlQeVsU=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/internal/cac/storage/tenant_storage.go
+++ b/internal/cac/storage/tenant_storage.go
@@ -2,7 +2,9 @@ package storage
 
 import (
     "context"
+    "encoding/json"
     "github.com/cloudentity/acp-client-go/clients/hub/models"
+    smodels "github.com/cloudentity/acp-client-go/clients/system/models"
     "github.com/cloudentity/cac/internal/cac/api"
     "github.com/cloudentity/cac/internal/cac/utils"
     "path/filepath"
@@ -28,6 +30,10 @@ func (t *TenantStorage) Write(ctx context.Context, data models.Rfc7396PatchOpera
     )
 
     if model, err = utils.FromPatchToModel[models.TreeTenant](data); err != nil {
+        return err
+    }
+
+    if err = t.storeTenant(path, model); err != nil {
         return err
     }
 
@@ -193,6 +199,25 @@ func (t *TenantStorage) Read(ctx context.Context, opts ...api.SourceOpt) (models
 }
 
 var _ Storage = &TenantStorage{}
+
+func (t *TenantStorage) storeTenant(path string, data *models.TreeTenant) error {
+    var (
+        tenant smodels.Tenant
+        bts    []byte
+        err    error
+    )
+
+    // serialize the tenant data into system/models to remove the dependencies which are stored in separate files
+    if bts, err = json.Marshal(data); err != nil {
+        return err
+    }
+
+    if err = json.Unmarshal(bts, &tenant); err != nil {
+        return err
+    }
+
+    return writeFile(tenant, filepath.Join(path, "tenant"))
+}
 
 func storeTemplates(templates models.TreeTemplates, path string) error {
     for id, template := range templates {

--- a/internal/cac/storage/tenant_storage_test.go
+++ b/internal/cac/storage/tenant_storage_test.go
@@ -189,6 +189,12 @@ webauthn_settings:
                 Metadata: models.TenantMetadata{
                     "owner": "platform-team",
                 },
+                Settings: &models.TenantSettings{
+                    MessageRedaction: &models.RedactionPolicy{
+                        Address: "obfuscate",
+                        Content: "retain",
+                    },
+                },
                 MfaMethods: models.TreeMFAMethods{
                     "sms": models.TreeMFAMethod{
                         Enabled:   true,
@@ -206,7 +212,11 @@ webauthn_settings:
                     require.YAMLEq(t, `name: Default
 url: https://example.com/default
 metadata:
-  owner: platform-team`, string(bts))
+  owner: platform-team
+settings:
+  message_redaction:
+    address: obfuscate
+    content: retain`, string(bts))
                 }
             },
         },

--- a/internal/cac/storage/tenant_storage_test.go
+++ b/internal/cac/storage/tenant_storage_test.go
@@ -168,6 +168,7 @@ identifier_case_insensitive: false
 mfa_session_ttl: 0s
 name: Idp-datamigration-pool
 otp_settings:
+  require_user_confirmation_before_send: false
   verify_address:
     length: 6
     ttl: 5m0s
@@ -178,6 +179,35 @@ webauthn_settings:
   rp_id: example.com
   rp_origins:
     - https://www.sit2.example.com`, string(bts))
+            },
+        },
+        {
+            desc: "tenant level configuration",
+            data: &models.TreeTenant{
+                Name: "Default",
+                URL:  "https://example.com/default",
+                Metadata: models.TenantMetadata{
+                    "owner": "platform-team",
+                },
+                MfaMethods: models.TreeMFAMethods{
+                    "sms": models.TreeMFAMethod{
+                        Enabled:   true,
+                        Mechanism: "sms",
+                    },
+                },
+            },
+            files: []string{
+                "tenant.yaml",
+                "mfa_methods/sms.yaml",
+            },
+            assert: func(t *testing.T, path string, bts []byte) {
+                switch path {
+                case "tenant.yaml":
+                    require.YAMLEq(t, `name: Default
+url: https://example.com/default
+metadata:
+  owner: platform-team`, string(bts))
+                }
             },
         },
         {


### PR DESCRIPTION
## What

Adds a top-level `tenant.yaml` to **tenant storage**, mirroring `server.yaml` in **server storage**.

Previously `TenantStorage.Write` persisted `pools/`, `schemas/`, `mfa_methods/`, `themes/`, and delegated `servers/` — but never wrote the tenant-level fields, so they were silently dropped on write. The read side already looked for an (optional) `tenant.yaml`; this fills in the missing write half.

## How

- New `storeTenant` method, a near-exact mirror of `storeServer`: it round-trips `TreeTenant` through the system `Tenant` model (`smodels.Tenant`), which keeps only the tenant-level fields — `name`, `url`, `jwks`, `metadata`, `settings`, `styling` — and drops the collections stored as separate files. Using the dedicated system model (rather than a hand-maintained delete list) means new collection fields on `TreeTenant` can't accidentally leak into `tenant.yaml`.
- Wired into `TenantStorage.Write` right after the model is parsed.

## Backwards compatibility

`tenant.yaml` is **optional on read** — a missing file yields an empty base map without error (existing behavior of `readFile`), so existing on-disk configs keep working. `writeFile` also skips zero-value data, so a tenant with no top-level fields produces no file.

## Tests

- New `tenant level configuration` round-trip case asserting `tenant.yaml` is produced with the expected content and that the fields survive write→read.
- Full suite green (`go test ./...`).

## Note

Includes an `acp-client-go` bump (`b244b5048247` → `008ff5049411`); the `otp_settings` pool-test expectation is aligned with the updated model (`require_user_confirmation_before_send`).