### PR TITLE
DEVOPS-8397: chore(security): pin external GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
       - name: Build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,11 +12,11 @@ jobs:
   golangci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
           args: --timeout=5m

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,15 +12,15 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: latest
@@ -32,7 +32,7 @@ jobs:
     needs: goreleaser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.ref_name }}
       - uses: ./
@@ -46,7 +46,7 @@ jobs:
     needs: goreleaser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.ref_name }}
       - uses: ./

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
         needs: resolve-tag
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: ${{ needs.resolve-tag.outputs.tag }}
           - uses: ./
@@ -45,7 +45,7 @@ jobs:
         needs: resolve-tag
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: ${{ needs.resolve-tag.outputs.tag }}
           - uses: ./

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Restore cached binary
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /tmp/cac
         key: cac-${{ runner.os }}-${{ runner.arch }}-${{ github.action_ref || github.ref_name }}
@@ -54,7 +54,7 @@ runs:
 
     - name: Install Go
       if: steps.download.outcome == 'failure' && steps.go-check.outputs.preinstalled != 'true'
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version-file: '${{ github.action_path }}/go.mod'
 


### PR DESCRIPTION
## Summary

Pin every **external** third-party GitHub Action to a full-length commit SHA with a
trailing version comment, mitigating the mutable-tag supply-chain attack class
(e.g. the `tj-actions/changed-files` compromise). A moved tag can no longer swap
code into our CI — the SHA is immutable, and the comment preserves the original
version for readability and Renovate updates.

Internal `SecureAuthCorp/*` references are intentionally left on floating tags
(`@main` / `@v1`) — same-org sources where floating is by design and the
external-maintainer threat does not apply.

No functional change: every SHA resolves to the exact commit the existing tag
currently points to.

This mirrors the org `github-actions` repo change (PR #90).

JIRA: https://secureauth.atlassian.net/browse/DEVOPS-8397
