### PR TITLE
ci: mirror assignee approval as bot approval when no unresolved comments

### DIFF
--- a/.github/workflows/assignee-approval-sync.yaml
+++ b/.github/workflows/assignee-approval-sync.yaml
@@ -1,0 +1,58 @@
+name: Sync bot approval with assignee
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+  pull_request:
+    types: [assigned, unassigned, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      - name: Mirror assignee approval as a second (bot) approval
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT: "github-actions[bot]"
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          assignees=$(gh pr view "$PR" -R "$REPO" --json assignees -q '.assignees[].login')
+          reviews=$(gh api "/repos/$REPO/pulls/$PR/reviews" --paginate --jq '.[]' | jq -s '.')
+
+          # Latest review of any non-author assignee is APPROVED?
+          # (GitHub ignores the author's own approval for required approvals.)
+          approved=false
+          for a in $assignees; do
+            [ "$a" = "$AUTHOR" ] && continue
+            state=$(echo "$reviews" | jq -r --arg u "$a" \
+              '[.[]|select(.user.login==$u)]|last|.state // empty')
+            [ "$state" = "APPROVED" ] && approved=true
+          done
+
+          # Any unresolved review threads block the bot approval.
+          unresolved=$(gh api graphql \
+            -F owner="${REPO%/*}" -F name="${REPO#*/}" -F pr="$PR" -f query='
+              query($owner: String!, $name: String!, $pr: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $pr) {
+                    reviewThreads(first: 100) { nodes { isResolved } }
+                  }
+                }
+              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length')
+
+          # Bot's active approval = its latest review, only if still APPROVED
+          botrev=$(echo "$reviews" | jq -r --arg b "$BOT" \
+            '([.[]|select(.user.login==$b)]|last) as $r | if $r.state=="APPROVED" then $r.id else empty end')
+
+          if $approved && [ "$unresolved" -eq 0 ] && [ -z "$botrev" ]; then
+            gh pr review "$PR" -R "$REPO" --approve --body "Auto-approve: assignee approved and no unresolved comments."
+          elif { ! $approved || [ "$unresolved" -gt 0 ]; } && [ -n "$botrev" ]; then
+            gh api -X PUT "/repos/$REPO/pulls/$PR/reviews/$botrev/dismissals" \
+              -f message="Approval conditions no longer met — dismissing bot approval."
+          fi

--- a/.github/workflows/assignee-approval-sync.yaml
+++ b/.github/workflows/assignee-approval-sync.yaml
@@ -35,6 +35,10 @@ jobs:
             [ "$state" = "APPROVED" ] && approved=true
           done
 
+          # Copilot must have reviewed this PR for the bot approval to apply.
+          copilot_reviewed=$(echo "$reviews" | jq -r \
+            '[.[]|select(.user.login=="copilot-pull-request-reviewer[bot]")]|length > 0')
+
           # Any unresolved review threads block the bot approval.
           unresolved=$(gh api graphql \
             -F owner="${REPO%/*}" -F name="${REPO#*/}" -F pr="$PR" -f query='
@@ -50,9 +54,9 @@ jobs:
           botrev=$(echo "$reviews" | jq -r --arg b "$BOT" \
             '([.[]|select(.user.login==$b)]|last) as $r | if $r.state=="APPROVED" then $r.id else empty end')
 
-          if $approved && [ "$unresolved" -eq 0 ] && [ -z "$botrev" ]; then
-            gh pr review "$PR" -R "$REPO" --approve --body "Auto-approve: assignee approved and no unresolved comments."
-          elif { ! $approved || [ "$unresolved" -gt 0 ]; } && [ -n "$botrev" ]; then
+          if $approved && $copilot_reviewed && [ "$unresolved" -eq 0 ] && [ -z "$botrev" ]; then
+            gh pr review "$PR" -R "$REPO" --approve --body "Auto-approve: assignee approved, Copilot reviewed, and no unresolved comments."
+          elif { ! $approved || ! $copilot_reviewed || [ "$unresolved" -gt 0 ]; } && [ -n "$botrev" ]; then
             gh api -X PUT "/repos/$REPO/pulls/$PR/reviews/$botrev/dismissals" \
               -f message="Approval conditions no longer met — dismissing bot approval."
           fi

--- a/.github/workflows/assignee-approval-sync.yaml
+++ b/.github/workflows/assignee-approval-sync.yaml
@@ -22,6 +22,8 @@ jobs:
           REPO: ${{ github.repository }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
+          set -euo pipefail
+
           assignees=$(gh pr view "$PR" -R "$REPO" --json assignees -q '.assignees[].login')
           reviews=$(gh api "/repos/$REPO/pulls/$PR/reviews" --paginate --jq '.[]' | jq -s '.')
 
@@ -40,15 +42,20 @@ jobs:
             '[.[]|select(.user.login=="copilot-pull-request-reviewer[bot]")]|length > 0')
 
           # Any unresolved review threads block the bot approval.
-          unresolved=$(gh api graphql \
+          # --paginate walks all pages; --jq emits a per-page count, summed below.
+          unresolved=$(gh api graphql --paginate \
             -F owner="${REPO%/*}" -F name="${REPO#*/}" -F pr="$PR" -f query='
-              query($owner: String!, $name: String!, $pr: Int!) {
+              query($owner: String!, $name: String!, $pr: Int!, $endCursor: String) {
                 repository(owner: $owner, name: $name) {
                   pullRequest(number: $pr) {
-                    reviewThreads(first: 100) { nodes { isResolved } }
+                    reviewThreads(first: 100, after: $endCursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes { isResolved }
+                    }
                   }
                 }
-              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length')
+              }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' \
+            | awk '{s+=$1} END {print s+0}')
 
           # Bot's active approval = its latest review, only if still APPROVED
           botrev=$(echo "$reviews" | jq -r --arg b "$BOT" \


### PR DESCRIPTION
## Summary

Adds an `assignee-approval-sync` workflow that mirrors an assignee's approval as a second (`github-actions[bot]`) approval:

- **Approves** when all of the following hold:
  - at least one non-author assignee's latest review is APPROVED,
  - Copilot (`copilot-pull-request-reviewer[bot]`) has reviewed the PR,
  - the PR has no unresolved review threads (GraphQL `reviewThreads` check).
- **Dismisses** the bot approval when any condition stops holding.
- Skips dependabot PRs and forked-repo PRs.
- Triggers on review submitted/dismissed/edited, PR assigned/unassigned, and `synchronize` so conditions are re-checked after new pushes (GitHub fires no event when a thread is resolved). Copilot finishing a (re-)review submits a real review, so it triggers the sync too.

## Notes

- Resolving the last open thread doesn't trigger any event; the bot approval lands on the next review/assignment/push event.
- Validated with `actionlint`.